### PR TITLE
Changes to add DRA feature gates to config on conditional basis and setting v1.32 k8s as default version

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ module "crusoe" {
   ib_partition_id = "6dcef748-dc30-49d8-9a0b-6ac87a27b4f8"
   headnode_instance_type="c1a.8x"
   deploy_location = "us-east1-a"
+  enable_dra_feature = false
   # extra variables here
 }
 ```
@@ -41,8 +42,11 @@ worker_count = 2
 ib_partition_id = "6dcef748-dc30-49d8-9a0b-6ac87a27b4f8"
 headnode_instance_type="c1a.8x"
 deploy_location = "us-east1-a"
+enable_dra_feature = false
 # extra variables here
 ```
+Note: For GB200 SKU as `worker_instance_type`, set `enable_dra_feature = true`.
+
 
 And then apply, to provision resources
 
@@ -66,6 +70,8 @@ sed -i '' "s/127.0.0.1/${rke_endpoint}/g" ./kubeconfig
 sed -i '' "s/default/crusoe/g" ./kubeconfig
 export KUBECONFIG="$(pwd)/kubeconfig"
 ```
+
+Note: For GB200 SKU, please refer to [Knowledge Base Article](https://support.crusoecloud.com/hc/en-us/articles/41038210396443-NCCL-Performance-Validation-for-GB200-on-RKE2-Cluster-with-Dynamic-Resource-Allocation) for GPU support and NCCL Performance validation steps.
 
 ## Nvidia GPU Support
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ module "crusoe" {
   headnode_instance_type="c1a.8x"
   deploy_location = "us-east1-a"
   enable_dra_feature = false
+  rke_version = "v1.32.6+rke2r1"
   # extra variables here
 }
 ```
@@ -43,6 +44,7 @@ ib_partition_id = "6dcef748-dc30-49d8-9a0b-6ac87a27b4f8"
 headnode_instance_type="c1a.8x"
 deploy_location = "us-east1-a"
 enable_dra_feature = false
+rke_version = "v1.32.6+rke2r1"
 # extra variables here
 ```
 Note: For GB200 SKU as `worker_instance_type`, set `enable_dra_feature = true`.

--- a/main.tf
+++ b/main.tf
@@ -90,6 +90,7 @@ resource "crusoe_compute_instance" "rke_headnode" {
       is_main_headnode = count.index == 0
       headnode_has_ib = local.headnode_has_ib
       enable_dra_feature = var.enable_dra_feature
+      rke_version         = var.rke_version
     }
   )
   host_channel_adapters = local.headnode_has_ib ? [{ ib_partition_id = var.ib_partition_id }] : null
@@ -143,6 +144,7 @@ resource "crusoe_compute_instance" "workers" {
   image                 = var.worker_image
   startup_script        = templatefile("${path.module}/rkeinstall-worker-wrapper.sh.tftpl", {
   enable_dra_feature    = var.enable_dra_feature
+  rke_version           = var.rke_version
   worker_script         = file("${path.module}/rkeinstall-worker.sh")
   })
   host_channel_adapters = local.worker_has_ib ? [{ ib_partition_id = var.ib_partition_id }] : null

--- a/main.tf
+++ b/main.tf
@@ -89,6 +89,7 @@ resource "crusoe_compute_instance" "rke_headnode" {
     {
       is_main_headnode = count.index == 0
       headnode_has_ib = local.headnode_has_ib
+      enable_dra_feature = var.enable_dra_feature
     }
   )
   host_channel_adapters = local.headnode_has_ib ? [{ ib_partition_id = var.ib_partition_id }] : null
@@ -140,7 +141,10 @@ resource "crusoe_compute_instance" "workers" {
   ssh_key               = var.ssh_pubkey
   location              = var.deploy_location
   image                 = var.worker_image
-  startup_script        = file("${path.module}/rkeinstall-worker.sh")
+  startup_script        = templatefile("${path.module}/rkeinstall-worker-wrapper.sh.tftpl", {
+  enable_dra_feature    = var.enable_dra_feature
+  worker_script         = file("${path.module}/rkeinstall-worker.sh")
+  })
   host_channel_adapters = local.worker_has_ib ? [{ ib_partition_id = var.ib_partition_id }] : null
   provisioner "file" {
     content     = jsonencode(crusoe_compute_instance.rke_headnode[0])

--- a/rkeinstall-headnode.sh.tftpl
+++ b/rkeinstall-headnode.sh.tftpl
@@ -51,7 +51,7 @@ kubelet-arg:
 
 EOF
 
-curl -sfL https://get.rke2.io | INSTALL_RKE2_VERSION="v1.32.6+rke2r1" sh -s
+curl -sfL https://get.rke2.io | INSTALL_RKE2_VERSION="${rke_version}" sh -s
 systemctl enable rke2-server.service
 systemctl start rke2-server.service
 
@@ -87,7 +87,7 @@ kubelet-arg:
 
 EOF
 
-curl -sfL https://get.rke2.io | INSTALL_RKE2_VERSION="v1.32.6+rke2r1" sh -s
+curl -sfL https://get.rke2.io | INSTALL_RKE2_VERSION="${rke_version}" sh -s
 systemctl enable rke2-server.service
 systemctl start rke2-server.service
 

--- a/rkeinstall-headnode.sh.tftpl
+++ b/rkeinstall-headnode.sh.tftpl
@@ -37,9 +37,21 @@ write-kubeconfig-mode: "0654"
 tls-san:
   - $lb_host
   - $main_headnode_pub_ip
+%{ if enable_dra_feature }
+kube-apiserver-arg:
+  - "--feature-gates=DynamicResourceAllocation=true"
+  - "--runtime-config=resource.k8s.io/v1beta1=true"
+kube-controller-manager-arg:
+  - "--feature-gates=DynamicResourceAllocation=true"
+kube-scheduler-arg:
+  - "--feature-gates=DynamicResourceAllocation=true"
+kubelet-arg:
+  - "--feature-gates=DynamicResourceAllocation=true"
+%{ endif }
+
 EOF
 
-curl -sfL https://get.rke2.io | sh -s
+curl -sfL https://get.rke2.io | INSTALL_RKE2_VERSION="v1.32.6+rke2r1" sh -s
 systemctl enable rke2-server.service
 systemctl start rke2-server.service
 
@@ -61,9 +73,21 @@ write-kubeconfig-mode: "0654"
 tls-san:
   - $lb_host
   - $main_headnode_pub_ip
+%{ if enable_dra_feature }
+kube-apiserver-arg:
+  - "--feature-gates=DynamicResourceAllocation=true"
+  - "--runtime-config=resource.k8s.io/v1beta1=true"
+kube-controller-manager-arg:
+  - "--feature-gates=DynamicResourceAllocation=true"
+kube-scheduler-arg:
+  - "--feature-gates=DynamicResourceAllocation=true"
+kubelet-arg:
+  - "--feature-gates=DynamicResourceAllocation=true"
+%{ endif }
+
 EOF
 
-curl -sfL https://get.rke2.io | sh -s
+curl -sfL https://get.rke2.io | INSTALL_RKE2_VERSION="v1.32.6+rke2r1" sh -s
 systemctl enable rke2-server.service
 systemctl start rke2-server.service
 

--- a/rkeinstall-worker-wrapper.sh.tftpl
+++ b/rkeinstall-worker-wrapper.sh.tftpl
@@ -9,7 +9,19 @@ cat << EOF >> /etc/rancher/rke2/config.yaml
 kubelet-arg:
   - "--feature-gates=DynamicResourceAllocation=true"
 EOF
-systemctl restart rke2-agent.service
+
 systemctl disable --now nvidia-imex.service
 systemctl mask nvidia-imex.service
 %{ endif }
+
+#Starting RKE2 agent
+export INSTALL_RKE2_TYPE="agent"
+export INSTALL_RKE2_VERSION="${rke_version}"
+curl -sfL https://get.rke2.io | sh -
+
+#Restarting RKE2 agent
+systemctl enable rke2-agent.service
+systemctl start rke2-agent.service
+
+#Wait until the service file exists
+while [ ! -f /etc/systemd/system/rke2-agent.service ]; do sleep 1; done

--- a/rkeinstall-worker-wrapper.sh.tftpl
+++ b/rkeinstall-worker-wrapper.sh.tftpl
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Run main worker script
+${worker_script}
+
+%{ if enable_dra_feature }
+echo "Applying DynamicResourceAllocation feature gate to worker..."
+cat << EOF >> /etc/rancher/rke2/config.yaml
+kubelet-arg:
+  - "--feature-gates=DynamicResourceAllocation=true"
+EOF
+systemctl restart rke2-agent.service
+systemctl disable --now nvidia-imex.service
+systemctl mask nvidia-imex.service
+%{ endif }

--- a/rkeinstall-worker.sh
+++ b/rkeinstall-worker.sh
@@ -34,7 +34,7 @@ EOF
 
 #Starting RKE2 agent
 
-curl -sfL https://get.rke2.io | INSTALL_RKE2_TYPE="agent" sh -
+curl -sfL https://get.rke2.io | INSTALL_RKE2_VERSION="v1.32.6+rke2r1" sh -s
 
 #Restarting RKE2 agent
 

--- a/rkeinstall-worker.sh
+++ b/rkeinstall-worker.sh
@@ -31,12 +31,3 @@ cat << EOF > /etc/rancher/rke2/config.yaml
 server: https://$lb_host:9345
 token: $rke_token
 EOF
-
-#Starting RKE2 agent
-
-curl -sfL https://get.rke2.io | INSTALL_RKE2_VERSION="v1.32.6+rke2r1" sh -s
-
-#Restarting RKE2 agent
-
-systemctl enable rke2-agent.service
-systemctl start rke2-agent.service

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -7,4 +7,5 @@ ib_partition_id = ""
 headnode_count = 2
 headnode_instance_type="c1a.8x"
 deploy_location = ""
+enable_dra_feature = false
 # extra variables here

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -8,4 +8,5 @@ headnode_count = 2
 headnode_instance_type="c1a.8x"
 deploy_location = ""
 enable_dra_feature = false
+rke_version = "v1.32.6+rke2r1"
 # extra variables here

--- a/variables.tf
+++ b/variables.tf
@@ -56,3 +56,9 @@ variable "enable_dra_feature" {
   type        = bool
   default     = false
 }
+
+variable "rke_version" {
+  description = "RKE2 version to install"
+  type        = string
+  default     = "v1.32.6+rke2r1"  # default
+}

--- a/variables.tf
+++ b/variables.tf
@@ -50,3 +50,9 @@ variable "instance_name_prefix" {
   description = "Prefix to use for the instance names"
   default     = "crusoe"
 }
+
+variable "enable_dra_feature" {
+  description = "Add extra config settings for DynamicResourceAllocation for GB200s"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
terraform.tfvars
```
worker_instance_type = "gb200-186gb-nvl.4x"
worker_image = "ubuntu24.04-nvidia-nvl-arm64-gb200"
worker_count = 18
ib_partition_id = ""
headnode_count = 2
headnode_instance_type="c1a.8x"
deploy_location = "eu-iceland1-a"
enable_dra_feature = true
rke_version = "v1.32.6+rke2r1"
```

```
terraform apply -var="ssh_pubkey=$(cat ~/.ssh/id_ed25519.pub)" -var="ssh_privkey_path=/Users/spathak/.ssh/id_ed25519"
```

```
$ kubectl get nodes
NAME                   STATUS   ROLES                       AGE    VERSION
crusoe-rke-0           Ready    control-plane,etcd,master   127m   v1.32.6+rke2r1
crusoe-rke-1           Ready    control-plane,etcd,master   126m   v1.32.6+rke2r1
crusoe-rke-worker-0    Ready    <none>                      115m   v1.32.6+rke2r1
crusoe-rke-worker-1    Ready    <none>                      126m   v1.32.6+rke2r1
crusoe-rke-worker-10   Ready    <none>                      115m   v1.32.6+rke2r1
crusoe-rke-worker-11   Ready    <none>                      125m   v1.32.6+rke2r1
crusoe-rke-worker-12   Ready    <none>                      115m   v1.32.6+rke2r1
crusoe-rke-worker-13   Ready    <none>                      126m   v1.32.6+rke2r1
crusoe-rke-worker-14   Ready    <none>                      126m   v1.32.6+rke2r1
crusoe-rke-worker-15   Ready    <none>                      115m   v1.32.6+rke2r1
crusoe-rke-worker-16   Ready    <none>                      125m   v1.32.6+rke2r1
crusoe-rke-worker-17   Ready    <none>                      126m   v1.32.6+rke2r1
crusoe-rke-worker-2    Ready    <none>                      126m   v1.32.6+rke2r1
crusoe-rke-worker-3    Ready    <none>                      126m   v1.32.6+rke2r1
crusoe-rke-worker-4    Ready    <none>                      126m   v1.32.6+rke2r1
crusoe-rke-worker-5    Ready    <none>                      115m   v1.32.6+rke2r1
crusoe-rke-worker-6    Ready    <none>                      126m   v1.32.6+rke2r1
crusoe-rke-worker-7    Ready    <none>                      126m   v1.32.6+rke2r1
crusoe-rke-worker-8    Ready    <none>                      115m   v1.32.6+rke2r1
crusoe-rke-worker-9    Ready    <none>                      126m   v1.32.6+rke2r1
```

On master node:
```
ubuntu@crusoe-rke-0:~$ cat /etc/rancher/rke2/config.yaml
write-kubeconfig-mode: "0654"
tls-san:
  - 160.211.64.111
  - 160.211.64.63

kube-apiserver-arg:
  - "--feature-gates=DynamicResourceAllocation=true"
  - "--runtime-config=resource.k8s.io/v1beta1=true"
kube-controller-manager-arg:
  - "--feature-gates=DynamicResourceAllocation=true"
kube-scheduler-arg:
  - "--feature-gates=DynamicResourceAllocation=true"
kubelet-arg:
  - "--feature-gates=DynamicResourceAllocation=true"
```

On worker node:
```
ubuntu@crusoe-rke-worker-17:~$ cat /etc/rancher/rke2/config.yaml
server: https://172.27.56.228:9345
token: K10112df5aec2f5e0c1f98cb4eb14f7673e68c34537856b6e021f30e91cf0ae43e8::server:14172e85795774d5964d9ef7211f9daa
kubelet-arg:
  - "--feature-gates=DynamicResourceAllocation=true"
```
```
ubuntu@crusoe-rke-worker-17:~$ systemctl status nvidia-imex.service
○ nvidia-imex.service
     Loaded: masked (Reason: Unit nvidia-imex.service is masked.)
     Active: inactive (dead)

Sep 13 20:05:50 crusoe-rke-worker-17 systemd[1]: Starting nvidia-imex.service - NVIDIA IMEX service...
Sep 13 20:05:50 crusoe-rke-worker-17 systemd[1]: nvidia-imex.service: Deactivated successfully.
Sep 13 20:05:50 crusoe-rke-worker-17 systemd[1]: Started nvidia-imex.service - NVIDIA IMEX service.
```
Full Details: https://crusoe.atlassian.net/wiki/spaces/CS/pages/1906704401/GB200+Validation+on+RKE2+Cluster+with+DRA